### PR TITLE
feat: update CLAUDE.md with tech stack and existing agents

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,54 @@
+# Dependencies and build artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+node_modules/
+
+# Environment and secrets
+.env
+.env.local
+.env.*.local
+*.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE and editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Git
+.git/
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+tmp/
+temp/
+*.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ env/
 *~
 .DS_Store
 
+# Claude Code
+.claude/
+**/.claude/
+
 # Node
 node_modules/
 npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,30 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Language & Communication
+- Respond to the user in **Chinese (简体中文)**.
+- Technical terms and code-related discussions can remain in English.
+
+## Tech Stack & Commands
+- **Environment**: Use `conda` to manage the base environment.
+- **Package Manager**: Use `uv` for dependency management.
+  - Install: `uv pip install -r requirements.txt` or `uv pip install <package>`
+- **Linting**: Use `ruff`.
+  - Command: `ruff check --fix` and `ruff format`
+- **Testing**: Use `pytest`.
+  - Command: `pytest tests/`
+  - Run single test: `pytest tests/path/to/test_file.py::test_function`
+
+## Git Behavior
+- **Commit Style**: Conventional Commits (e.g., `feat:`, `fix:`, `chore:`).
+- **Atomic Commits**: Keep changes small and focused.
+- **Pre-flight Check**: Before any commit, ensure `ruff` passes and `pytest` succeeds.
+
+## Coding Standards
+- **Type Hints**: Mandatory for all function signatures.
+- **Documentation**: Use Google-style docstrings for complex logic.
+- **Skills**: Follow the agentskills.io specification for any new agent capabilities.
+
 ## Project Overview
 
 This is a curated collection of **OpenClaw agents** and **skills** - a documentation and configuration repository for the OpenClaw AI agent framework. The repository contains definitions, templates, and examples for extending OpenClaw's capabilities.
@@ -112,6 +136,84 @@ From `docs/integration/agents-skills.md`:
 - Skills activate when user messages contain trigger keywords
 - Both agents and skills can use built-in tools (exec, read, write, web_search, etc.)
 - Skills are designed to be tool-agnostic - they instruct agents on which tools to use and how
+
+## Existing Agents & Skills
+
+### Agents in this Collection
+
+| Agent | Location | Purpose | Key Skills |
+|-------|----------|---------|-----------|
+| **fullstack-engineer** | `collection/agents/fullstack-engineer/` | 高级全栈工程师，专注于现代Web开发、可扩展架构和生产级代码 | opencode, claude-code, openspec |
+| **tech-cofounder** | `collection/agents/tech-cofounder/` | 技术联合创始人，提供创业项目的技术战略和执行指导 | - |
+| **research-agent** | `collection/agents/research-agent/` | 研究专家，用于深度调研和信息综合 | - |
+| **stock-analyst** | `collection/agents/stock-analyst/` | 股票分析师，专注于金融数据分析 | akshare, stock-analysis |
+
+### Skills in this Collection
+
+| Skill | Location | Purpose | Activation Keywords |
+|-------|----------|---------|-------------------|
+| **opencode** | `collection/skills/opencode/` | 开源AI编程代理，支持多代理编排和ultrawork模式 | opencode, ultrawork, ulw |
+| **claude-code** | `collection/skills/claude-code/` | Anthropic官方AI编程助手 | claude-code, anthropic coding |
+| **openspec** | `collection/skills/openspec/` | 规格驱动开发框架，使用Gherkin语法 | openspec, gherkin, bdd |
+| **akshare** | `collection/skills/akshare/` | 中国金融数据接口库 | stock data, akshare |
+| **stock-analysis** | `collection/skills/stock-analysis/` | 股票分析技能，提供技术指标和可视化 | stock analysis, technical indicators |
+
+## Project Structure Deep Dive
+
+### Key Files
+
+- **`AGENTS.md`**: 代理的总体文档和使用指南
+- **`SKILLS.md`**: 技能的总体文档和使用指南
+- **`CONTRIBUTING.md`**: 贡献指南和检查清单
+- **`templates/agent-template.md`**: 创建新代理的模板
+- **`templates/skill-template.md`**: 创建新技能的模板
+
+### Directory Organization
+
+```
+collection/
+├── agents/
+│   ├── agent-name/
+│   │   ├── AGENT.md          # 代理定义（必需）
+│   │   ├── README.md         # 用户友好的说明
+│   │   ├── examples/         # 使用示例
+│   │   ├── references/       # 参考文档
+│   │   └── assets/           # 图片等资源
+│   └── ...
+└── skills/
+    ├── skill-name/
+    │   ├── SKILL.md          # 技能定义（必需）
+    │   ├── examples/         # 使用示例
+    │   ├── references/       # 参考文档（如API文档）
+    │   ├── scripts/          # 辅助脚本（Python等）
+    │   └── assets/           # 图片等资源
+    └── ...
+```
+
+### Common Tasks
+
+#### Adding a New Agent
+
+1. 从模板创建目录结构
+2. 填写 `AGENT.md` 的所有必需章节
+3. 添加示例和参考资料
+4. 更新 `AGENTS.md` 索引
+
+#### Adding a New Skill
+
+1. 从模板创建目录结构
+2. 定义具体的激活关键词（避免通用词汇）
+3. 编写详细的分步指令
+4. 添加错误处理策略
+5. 更新 `SKILLS.md` 索引
+
+#### Working with Python Scripts
+
+项目中的Python脚本（如 `stock-analysis/scripts/`）应遵循：
+- 使用类型提示
+- 使用 Google 风格文档字符串
+- 通过 `ruff check --fix` 进行 linting
+- 通过 `ruff format` 进行格式化
 
 ## References
 


### PR DESCRIPTION
## Summary

更新 CLAUDE.md 文件，添加：

1. **技术栈和常用命令**
   - Conda 环境管理
   - uv 包管理器
   - ruff linting 和格式化
   - pytest 测试命令

2. **语言和通信规范**
   - 使用中文（简体中文）回复用户

3. **现有代理和技能概览**
   - 4 个代理的表格（fullstack-engineer、tech-cofounder、research-agent、stock-analyst）
   - 5 个技能的表格（opencode、claude-code、openspec、akshare、stock-analysis）

4. **项目结构深度解析**
   - 关键文件说明
   - 目录组织规范
   - 常见任务操作指南

5. **新增 .claudeignore 文件**
   - 排除不必要的文件（依赖、构建产物、日志、IDE文件等）

6. **更新 .gitignore**
   - 添加 .claude/ 目录忽略规则